### PR TITLE
Boletos da Sicredi Funcionando

### DIFF
--- a/lib/boleto/bancos/sicredi.js
+++ b/lib/boleto/bancos/sicredi.js
@@ -40,15 +40,18 @@ var Sicredi = (function () {
       + beneficiario.getNossoNumero()
       + beneficiario.getDigitoNossoNumero()
       + beneficiario.getAgenciaFormatada()
-      + beneficiario.getCodposto()
       + beneficiario.getCodigoBeneficiario()
       + '10').split('');
-		var pesos = [9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+		var pesos = [9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
 
 		var soma = 0;
 
 		for (let i = 0; i < arrayDigitoCampoLivre.length; i++) {
-			soma += pesos[i] * parseInt(arrayDigitoCampoLivre[i], 10);
+			if(parseInt(arrayDigitoCampoLivre[i]) != 0){
+
+				soma += pesos[i] * parseInt(arrayDigitoCampoLivre[i]);
+			}
+			
 		}
 		var digCampoLivre = soma % 11;
 		if (digCampoLivre == 1 || digCampoLivre == 0) {
@@ -63,8 +66,7 @@ var Sicredi = (function () {
 		campoLivre.push(beneficiario.getNossoNumero().substring(3, 8));
 		campoLivre.push(beneficiario.getDigitoNossoNumero());
 		campoLivre.push(beneficiario.getAgenciaFormatada());
-		campoLivre.push(beneficiario.getCodposto());
-		campoLivre.push(beneficiario.getCodigoBeneficiario());
+		campoLivre.push(this.getCodigoFormatado(beneficiario));
 		campoLivre.push('1');
 		campoLivre.push('0');
 		campoLivre.push(digCampoLivre);
@@ -123,14 +125,14 @@ var Sicredi = (function () {
 	Sicredi.prototype.getAgenciaECodigoBeneficiario = function (boleto) {
 		var beneficiario = boleto.getBeneficiario(),
 
-			codigo = beneficiario.getCodposto() + '.' + beneficiario.getCodigoBeneficiario(),
+			codigo = this.getCodigoFormatado(beneficiario),
 			digitoCodigo = beneficiario.getDigitoCodigoBeneficiario();
 
 		if (digitoCodigo) {
 			codigo += '-' + digitoCodigo;
 		}
 
-		return beneficiario.getAgenciaFormatada() + '.' + codigo;
+		return beneficiario.getAgenciaFormatada() + '/' + codigo;
 	};
 
 	Sicredi.novoSicredi = function () {


### PR DESCRIPTION
A função de gerar boletos da Sicredi não estava funcionando, **mas agora está corrigido**.

O erro acontecia pelo variável `digCampoLivre` estar retornando `NaN`, e isso acontecia por diversos fatores:
- Multiplicação por `0`;
- O Array `pesos` com valores insuficientes;
- A existência de um `getCodposto()`, que retornava `undefined`;
- Número da conta podendo ser de um tamanho diferente do padrão.

O último item listado, sobre o número da conta em um tamanho diferente do padrão, foi corrigido com uma tratativa de tamanho (que estava presente para os demais bancos).