### PR TITLE
Geração do QRCode para pagamento do boleto via Pix.

### DIFF
--- a/examples/gerar-boleto-BancoDoBrasil.js
+++ b/examples/gerar-boleto-BancoDoBrasil.js
@@ -1,60 +1,70 @@
 const { Bancos, Boletos, streamToPromise } = require('../lib/index');
+const QrCode = require("qrcode");
 
-const boleto = {
-  banco: new Bancos.BancoBrasil(),
-  pagador: {
-    nome: 'José Bonifácio de Andrada',
-    registroNacional: '12345678',
-    endereco: {
-      logradouro: 'Rua Pedro Lessa, 15',
-      bairro: 'Centro',
-      cidade: 'Rio de Janeiro',
-      estadoUF: 'RJ',
-      cep: '20030-030'
-    }
-  },
-  instrucoes: ['Após o vencimento Mora dia R$ 1,59', 'Após o vencimento, multa de 2%'],
-  beneficiario: {
-    nome: 'Empresa Fictícia LTDA',
-    cnpj:'43576788000191',
-    dadosBancarios: {
-      carteira: '09',
-      agencia: '18455',
-      agenciaDigito: '4',
-      conta: '1277165',
-      contaDigito: '1',
-      nossoNumero: '00000000061',
-      nossoNumeroDigito: '8'
+gerarBoletoBB();
+
+async function gerarBoletoBB(){
+  const boleto = {
+    banco: new Bancos.BancoBrasil(),
+    pagador: {
+      nome: 'José Bonifácio de Andrada',
+      registroNacional: '12345678',
+      endereco: {
+        logradouro: 'Rua Pedro Lessa, 15',
+        bairro: 'Centro',
+        cidade: 'Rio de Janeiro',
+        estadoUF: 'RJ',
+        cep: '20030-030'
+      }
     },
-    endereco: {
-      logradouro: 'Rua Pedro Lessa, 15',
-      bairro: 'Centro',
-      cidade: 'Rio de Janeiro',
-      estadoUF: 'RJ',
-      cep: '20030-030'
+    instrucoes: ['Após o vencimento Mora dia R$ 1,59', 'Após o vencimento, multa de 2%'],
+    beneficiario: {
+      nome: 'Empresa Fictícia LTDA',
+      cnpj:'43576788000191',
+      dadosBancarios: {
+        carteira: '09',
+        agencia: '18455',
+        agenciaDigito: '4',
+        conta: '1277165',
+        contaDigito: '1',
+        nossoNumero: '00000000061',
+        nossoNumeroDigito: '8'
+      },
+      endereco: {
+        logradouro: 'Rua Pedro Lessa, 15',
+        bairro: 'Centro',
+        cidade: 'Rio de Janeiro',
+        estadoUF: 'RJ',
+        cep: '20030-030'
+      }
+    },
+    boleto: {
+      numeroDocumento: '1001',
+      especieDocumento: 'DM',
+      valor: 110.00,
+      datas: {
+        vencimento: '02-04-2020',
+        processamento: '02-04-2019',
+        documentos: '02-04-2019'
+      },
+      emv: "teste.com.br",
+      imagemQrCode: "",
     }
-  },
-  boleto: {
-    numeroDocumento: '1001',
-    especieDocumento: 'DM',
-    valor: 110.00,
-    datas: {
-      vencimento: '02-04-2020',
-      processamento: '02-04-2019',
-      documentos: '02-04-2019'
-    }
-  }
-};
+  };
 
-const novoBoleto = new Boletos(boleto);
-novoBoleto.gerarBoleto();
+  boleto.boleto.imagemQrCode = await gerarQrCodePix(boleto.boleto.emv);
 
-novoBoleto.pdfFile().then(async ({ stream }) => {
-  // ctx.res.set('Content-type', 'application/pdf');	
-  await streamToPromise(stream);
-}).catch((error) => {
-  return error;
-});
+  const novoBoleto = new Boletos(boleto);
+  novoBoleto.gerarBoleto();
 
+  novoBoleto.pdfFile().then(async ({ stream }) => {
+    // ctx.res.set('Content-type', 'application/pdf');	
+    await streamToPromise(stream);
+  }).catch((error) => {
+    return error;
+  });
+}
 
-
+async function gerarQrCodePix(emv) {
+  return QrCode.toDataURL(emv, { errorCorrectionLevel: "H" });
+}

--- a/examples/gerar-boleto-BancoDoBrasil.js
+++ b/examples/gerar-boleto-BancoDoBrasil.js
@@ -47,12 +47,14 @@ async function gerarBoletoBB(){
         processamento: '02-04-2019',
         documentos: '02-04-2019'
       },
-      emv: "teste.com.br",
+      emv: "teste.com.br", //preencher aqui com o texto do Pix Copia e Copia,
       imagemQrCode: "",
     }
   };
 
-  boleto.boleto.imagemQrCode = await gerarQrCodePix(boleto.boleto.emv);
+  if (boleto.boleto.emv){
+    boleto.boleto.imagemQrCode = await gerarQrCodePix(boleto.boleto.emv);
+  }
 
   const novoBoleto = new Boletos(boleto);
   novoBoleto.gerarBoleto();

--- a/lib/boleto/gerador-de-boleto.js
+++ b/lib/boleto/gerador-de-boleto.js
@@ -653,6 +653,31 @@ var GeradorDeBoleto = (function() {
 						align: 'left'
 					});
 
+				pdf
+				.font("normal")
+				.fontSize(args.tamanhoDaFonteDoTitulo + 1)
+				.text(
+					"Caso queira pagar via Pix, use o QrCode ao lado",
+					args.ajusteX + 280,
+					args.ajusteY + linha212 + 80,
+					{
+					lineBreak: false,
+					width: 294,
+					align: "left",
+					}
+				);
+		
+				// Gerar QR code e adicionar ao PDF
+				pdf.image(
+				boleto.getQrCode(),
+				args.ajusteX + 470,
+				args.ajusteY + linha212 + 40,
+				{
+					width: 100,
+					align: "right",
+				}
+				);					
+
 				var terceiraLinha = segundaLinha2 + 38,
 					tituloDaTerceiraLinha = terceiraLinha - diferencaEntreTituloEValor,
 					tituloDaTerceiraLinhaLateral = terceiraLinha - diferencaEntreTituloEValor,

--- a/lib/boleto/gerador-de-boleto.js
+++ b/lib/boleto/gerador-de-boleto.js
@@ -653,30 +653,32 @@ var GeradorDeBoleto = (function() {
 						align: 'left'
 					});
 
-				pdf
-				.font("normal")
-				.fontSize(args.tamanhoDaFonteDoTitulo + 1)
-				.text(
-					"Caso queira pagar via Pix, use o QrCode ao lado",
-					args.ajusteX + 280,
-					args.ajusteY + linha212 + 80,
+				if (boleto.getQrCode()) {
+					pdf
+					.font("normal")
+					.fontSize(args.tamanhoDaFonteDoTitulo + 1)
+					.text(
+						"Caso queira pagar via Pix, use o QrCode ao lado",
+						args.ajusteX + 280,
+						args.ajusteY + linha212 + 80,
+						{
+						lineBreak: false,
+						width: 294,
+						align: "left",
+						}
+					);
+			
+					// Gerar QR code e adicionar ao PDF
+					pdf.image(
+					boleto.getQrCode(),
+					args.ajusteX + 470,
+					args.ajusteY + linha212 + 40,
 					{
-					lineBreak: false,
-					width: 294,
-					align: "left",
+						width: 100,
+						align: "right",
 					}
-				);
-		
-				// Gerar QR code e adicionar ao PDF
-				pdf.image(
-				boleto.getQrCode(),
-				args.ajusteX + 470,
-				args.ajusteY + linha212 + 40,
-				{
-					width: 100,
-					align: "right",
+					);					
 				}
-				);					
 
 				var terceiraLinha = segundaLinha2 + 38,
 					tituloDaTerceiraLinha = terceiraLinha - diferencaEntreTituloEValor,

--- a/lib/metodosPublicos/boletoMetodos.js
+++ b/lib/metodosPublicos/boletoMetodos.js
@@ -27,7 +27,8 @@ module.exports = class Boletos {
       .comValorBoleto(parseFloat(valor).toFixed(2))
       .comNumeroDoDocumento(numeroDocumento)
       .comEspecieDocumento(especieDocumento)
-      .comInstrucoes(BoletoStringify.createInstrucoes(this.instrucoes));
+      .comInstrucoes(BoletoStringify.createInstrucoes(this.instrucoes))
+      .comQrCode(this.boleto.imagemQrCode);
   }
 
   pdfFile(dir = './tmp/boletos', filename='boleto') {

--- a/lib/utils/functions/boletoUtils.js
+++ b/lib/utils/functions/boletoUtils.js
@@ -867,8 +867,17 @@ var Boleto = (function () {
 		const numeroDocumento = this.getNumeroDoDocumentoFormatado();
 		const linha = GeradorDeLinhaDigitavel(this._banco.geraCodigoDeBarrasPara(this), this._banco);
 		const linhaDigitavel = {linha, numeroDocumento};
-		return linhaDigitavel;
+		return linhaDigitavel;		
 	};
+
+	Boleto.prototype.comQrCode = function (_qrCode) {
+		this._qrCode = _qrCode;
+		return this;
+	};
+	
+	Boleto.prototype.getQrCode = function () {
+		return this._qrCode;
+	};	
 
 	Boleto.novoBoleto = function () {
 		return new Boleto()

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "base64-stream": "^1.0.0",
     "moment": "^2.24.0",
-    "pdfkit": "0.10.0"
+    "pdfkit": "0.10.0",
+    "qrcode": "^1.5.3"
   },
   "devDependencies": {
     "eslint": "^6.5.1",


### PR DESCRIPTION
Fala galera,

Estou desenvolvendo o registro de boleto via API em meu trabalho, e cheguei no momento de gerar o .pdf do boleto registrado. Encontrei esse repositório e me ajudou demais com essa implementação.

No entanto, existia uma demanda para mim, devendo o boleto ser gerado com o QrCode para pagamento via Pix, visto que o Banco do Brasil oferece tal opção no momento do registro do boleto, o que ocasiona maior agilidade no momento da liquidação do título.

Portanto, fiz as alterações necessárias para que o QrCode fosse gerado no PDF.

As modificações resumem-se à obter o "qrcode_emv" disponibilizado pelo banco, gerar o qrcode desta string e por fim, adiciona-la no local correto do arquivo.

Meus conhecimentos em JS ainda são básicos, portanto, não ousei ir muito afundo nas modificações no projeto base, então acredito que existam melhorias possíveis em minha implementação.

Deixo abaixo um exemplo do qrcode gerado para pagamento via pix de um boleto quaisquer.

![image](https://github.com/Romulosanttos/gerar-boletos/assets/35407792/eb0e964a-2508-497e-9dad-52fd1c98dcaa)
