### PR TITLE
hotfix/ adequando datas a nova regra FEBRABAN

### DIFF
--- a/lib/utils/functions/boletoUtils.js
+++ b/lib/utils/functions/boletoUtils.js
@@ -602,13 +602,9 @@ var Boleto = (function () {
 
 	Boleto.prototype.getFatorVencimento = function () {
 		var vencimento = this.getDatas().getVencimento(),
-			diferencaEmDias = (vencimento - DATA_BASE) / (1000 * 60 * 60 * 24);
-
-		if (diferencaEmDias > 9999) {
-			throw new Error('Data fora do formato aceito');
-		}
-
-		return Math.floor(diferencaEmDias).toString();
+			diferencaEmDias =  Math.floor((vencimento - DATA_BASE) / (1000 * 60 * 60 * 24));
+		if(diferencaEmDias > 9999) diferencaEmDias -= 10000
+		return diferencaEmDias.toString().padStart(4, '0');
 	};
 
 	Boleto.prototype.comEspecieMoeda = function (_especieMoeda) {


### PR DESCRIPTION
A geração de boletos, criada em 1997, possui um limite de 9.999 caracteres, que são informados na linha digitável de cada boleto.

Considerando o alcance dessa data, fui motivado a desenvolver uma solução para esse problema.

A FEBRABAN (Federação Brasileira de Bancos) definiu que, ao atingir o limite de 9.999 dígitos (em 21/02/2025), os boletos gerados em sequência deverão reiniciar a contagem. Assim, no dia seguinte (22/02/2025), o código retornará para 0000 e seguirá dessa forma até uma nova definição ou até o alcance do novo limite (em 13/10/2049).

Dessa forma, desenvolvi uma solução simples, alterando parte da lógica do método "getFatorVencimento" para atender à nova regra imposta.

Espero que a solução seja útil e estou à disposição para ajudar em outras questões.